### PR TITLE
[Issue #9] Fixed error on GET:/exchanges/<exchangeName> when there ar…

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -17,7 +17,7 @@ var getExchange = function(exchangeName, exchangeId) {
 };
 
 var getExchangeIds = function(exchangeName) {
-    var exchangesByExchangeName = inMemoryExchangeDatabase[exchangeName];
+    var exchangesByExchangeName = inMemoryExchangeDatabase[exchangeName] || {};
     var exchangeIds = Object.keys(exchangesByExchangeName);
     return exchangeIds;
 };

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,0 +1,20 @@
+var expect = require('chai').expect
+  , src = require('.').src;
+
+var db = require(src('db'));
+
+describe('Database', function () {
+
+    describe('getExchangeIds()', function() {
+        it('Given no stored exchanges', function() {
+            var exchangeIds = db.getExchangeIds('exchangeName-with-no-saved-exchange');
+            expect(exchangeIds).to.deep.equal([]);
+        });
+
+        it('Given has stored exchanges', function() {
+            db.saveExchange('dummy', {id : 'dummyyId'});
+            var exchangeIds = db.getExchangeIds('dummy');
+            expect(exchangeIds).to.deep.equal(['dummyyId']);
+        });
+    })
+});


### PR DESCRIPTION
…e no stored exchanges by returning empty array instead