### PR TITLE
Improvements

### DIFF
--- a/src/app-config.js
+++ b/src/app-config.js
@@ -33,6 +33,7 @@ var postRouters = function(app) {
         res.send(JSON.stringify({
             status:err.status,
             message:err.message,
+            type: err.constructor.name,
             error:error
         }));
     });

--- a/src/app-config.js
+++ b/src/app-config.js
@@ -14,6 +14,13 @@ var preRouters = function(app) {
       next();
     });
 
+    // map json null to undefined
+    app.use(function (req, res, next) {
+        if (req.body && typeof(req.body.map) === 'function') {
+            req.body = req.body.map(x => x === null ? undefined : x);
+        }
+        next();
+    });
 };
 
 var postRouters = function(app) {

--- a/test/routes/exchanges.test.js
+++ b/test/routes/exchanges.test.js
@@ -90,7 +90,8 @@ describe('Exchange Route', function () {
         .expect(function (res) {
           expect(res.body).to.deep.equal({
             error: {},
-            message : error.message
+            message : error.message,
+            type: "Error"
           });
         })
         .end(function(err, res) {


### PR DESCRIPTION
Hi, here are two minor improvements:
  - map null values to undefined to ccxt, ccxt expects undefined for unset parameters, but we cannot set fields to undefined via json
  - pass error type name along with message

this is required for the go implementation ccxt/ccxt#3651